### PR TITLE
Add name to metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,3 +4,4 @@ license          "Apache 2.0"
 description      "Installs/Configures heavywater"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.1.0"
+name		 "heavywater"


### PR DESCRIPTION
This is required for the latest vagrant release. Just added the cookbook name to the metadata.
